### PR TITLE
Shrink and restyle the header with a new gradient logo and font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Car Rainbow are documented here. Versions follow [Semantic Versioning](https://semver.org/); dates reflect when each change landed on `main`.
 
+## [1.1.0] - 2026-06-07
+
+### Changed
+
+- Redesigned the header: shrank `.heading` to a more compact height, restyled the title as a gradient-text logo (`heading__logo`/`heading__icon`/`heading__title`) set in the new "Baloo 2" Google Font, and reworked `_heading.scss` to leave room for an upcoming settings button
+
 ## [1.0.0] - 2026-06-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "car-rainbow",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "source": "src/index.html",
   "scripts": {

--- a/src/index.html
+++ b/src/index.html
@@ -4,12 +4,18 @@
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>🌈 Car Rainbow 🌈</title>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@600;700&display=swap" rel="stylesheet" />
         <link href="./scss/style.scss" rel="stylesheet" />
     </head>
     <body>
         <main class="container">
             <div class="heading">
-                <h1>🌈 Car Rainbow 🌈</h1>
+                <h1 class="heading__logo">
+                    <span class="heading__icon" aria-hidden="true">🌈</span>
+                    <span class="heading__title">Car Rainbow</span>
+                </h1>
                 <p class="heading__info">Check off the cars as you see them!</p>
             </div>
             <div id="app" class="app"></div>

--- a/src/scss/_heading.scss
+++ b/src/scss/_heading.scss
@@ -1,6 +1,9 @@
 .heading {
-    display: inline-block;
+    align-items: center;
+    display: flex;
+    flex-direction: column;
     height: $height-heading;
+    justify-content: center;
     width: 100%;
 
     @media all and (min-width: $breakpoint-desktop) {
@@ -8,16 +11,40 @@
     }
 }
 
-.heading__info {
-    text-align: center;
+.heading__logo {
+    align-items: center;
+    display: flex;
+    gap: 0.25em;
+    justify-content: center;
+    margin: 0;
 }
 
-h1 {
-    text-align: center;
-    font-size: 2em;
-    margin: 0.5em 0;
+.heading__icon {
+    font-size: 1.4em;
+    line-height: 1;
 
     @media all and (min-width: $breakpoint-desktop) {
-        font-size: 3em;
+        font-size: 1.6em;
     }
+}
+
+.heading__title {
+    background: linear-gradient(90deg, #ff3b3b, #ff9a3b, #ffd93b, #4ade80, #38bdf8, #a78bfa);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    font-family: 'Baloo 2', 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+    font-size: 1.5em;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+
+    @media all and (min-width: $breakpoint-desktop) {
+        font-size: 2.1em;
+    }
+}
+
+.heading__info {
+    font-size: 0.85em;
+    margin: 0.3em 0 0;
+    text-align: center;
 }

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -1,7 +1,7 @@
 // Tokens
 $breakpoint-desktop: 400px;
 
-$height-heading: 15vh;
+$height-heading: 11vh;
 $height-game-status: 8vh;
 $height-car-rainbow: 62vh;
 $height-footer: 5vh;


### PR DESCRIPTION
Reduces $height-heading and reworks the markup/styles so the header
has room for an upcoming settings button, replaces the emoji-bracketed
title with a compact rainbow-icon + gradient-text wordmark, and switches
the heading typeface to the playful "Baloo 2" Google Font.

https://claude.ai/code/session_011Fqh7ccgF5Kbz4VUikWvWD