### PR TITLE
Shrink mobile header text, add sound effects, and a progress rainbow border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Car Rainbow are documented here. Versions follow [Semantic Versioning](https://semver.org/); dates reflect when each change landed on `main`.
 
+## [1.3.0] - 2026-06-07
+
+### Added
+
+- Sound effects via the Web Audio API (`src/js/sound.js`): a tone plays when a car is checked/unchecked or the board is replayed, and a short victory melody plays when all six cars are found
+- A rainbow border (`.app-frame`) wraps the app card and fills in segment by segment, in each car's matching color, as that car is checked off
+
+### Changed
+
+- Shrank the header title/icon/info text sizes on mobile (`_heading.scss`) so "Car Rainbow" fits comfortably on narrow phone viewports
+- Restructured `_app.scss`/`CarRainbow.jsx` to wrap the white `.app-card` surface in a new `.app-frame` that renders the progress-driven rainbow border
+
 ## [1.2.0] - 2026-06-07
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "car-rainbow",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "",
   "source": "src/index.html",
   "scripts": {

--- a/src/js/CarRainbow.jsx
+++ b/src/js/CarRainbow.jsx
@@ -3,6 +3,9 @@ import Car from './Car';
 import Footer from './Footer';
 import GameStatus from './GameStatus';
 import Replay from './Replay';
+import { playCheckSound, playReplaySound, playWinSong } from './sound';
+
+const RAINBOW_COLORS = ['#ff3b3b', '#ff9a3b', '#ffd93b', '#4ade80', '#38bdf8', '#a78bfa'];
 
 function CarRainbow() {
     const gameData = {
@@ -24,6 +27,14 @@ function CarRainbow() {
         return <Car key={index} color={updatedColor} onClick={carClick} />;
     });
 
+    const segmentSize = 360 / data.colors.length;
+    const frameGradient = `conic-gradient(${data.colors
+        .map((color, index) => {
+            const fill = color.active ? RAINBOW_COLORS[index % RAINBOW_COLORS.length] : 'rgba(43, 45, 66, 0.1)';
+            return `${fill} ${index * segmentSize}deg ${(index + 1) * segmentSize}deg`;
+        })
+        .join(', ')})`;
+
     function replayClick() {
         const updatedData = { ...data };
 
@@ -32,6 +43,7 @@ function CarRainbow() {
             return { ...color, active: false };
         });
 
+        playReplaySound();
         document.getElementById('replay').close();
         setData(updatedData);
     }
@@ -40,7 +52,10 @@ function CarRainbow() {
         const updatedData = { ...data };
         updatedData.colors[index].active = !updatedData.colors[index].active;
 
+        playCheckSound(updatedData.colors[index].active);
+
         if (updatedData.colors.every((color) => color.active)) {
+            playWinSong();
             document.getElementById('replay').showModal();
         }
 
@@ -48,11 +63,13 @@ function CarRainbow() {
     }
 
     return (
-        <div>
-            <GameStatus game={data} />
-            <div className="car-rainbow">{cars}</div>
-            <Replay replayClick={replayClick} />
-            <Footer />
+        <div className="app-frame" style={{ '--app-frame-gradient': frameGradient }}>
+            <div className="app-card">
+                <GameStatus game={data} />
+                <div className="car-rainbow">{cars}</div>
+                <Replay replayClick={replayClick} />
+                <Footer />
+            </div>
         </div>
     );
 }

--- a/src/js/sound.js
+++ b/src/js/sound.js
@@ -1,0 +1,64 @@
+let audioContext;
+
+function getContext() {
+    if (!audioContext) {
+        const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+        audioContext = new AudioContextClass();
+    }
+
+    if (audioContext.state === 'suspended') {
+        audioContext.resume();
+    }
+
+    return audioContext;
+}
+
+function playTone(context, frequency, startTime, duration, type, peakGain) {
+    const oscillator = context.createOscillator();
+    const gainNode = context.createGain();
+
+    oscillator.type = type;
+    oscillator.frequency.setValueAtTime(frequency, startTime);
+
+    gainNode.gain.setValueAtTime(0, startTime);
+    gainNode.gain.linearRampToValueAtTime(peakGain, startTime + 0.02);
+    gainNode.gain.exponentialRampToValueAtTime(0.0001, startTime + duration);
+
+    oscillator.connect(gainNode);
+    gainNode.connect(context.destination);
+
+    oscillator.start(startTime);
+    oscillator.stop(startTime + duration);
+}
+
+export function playCheckSound(active) {
+    const context = getContext();
+    playTone(context, active ? 660 : 392, context.currentTime, 0.14, 'triangle', 0.12);
+}
+
+export function playReplaySound() {
+    const context = getContext();
+    const now = context.currentTime;
+    playTone(context, 392, now, 0.12, 'sine', 0.1);
+    playTone(context, 523.25, now + 0.08, 0.16, 'sine', 0.1);
+}
+
+// A short victory melody, played note by note like a tiny MIDI tune.
+const WIN_SONG = [
+    [523.25, 0.16], // C5
+    [659.25, 0.16], // E5
+    [783.99, 0.16], // G5
+    [1046.5, 0.3], // C6
+    [783.99, 0.16], // G5
+    [1046.5, 0.45], // C6
+];
+
+export function playWinSong() {
+    const context = getContext();
+    let time = context.currentTime + 0.05;
+
+    WIN_SONG.forEach(([frequency, duration]) => {
+        playTone(context, frequency, time, duration, 'square', 0.15);
+        time += duration * 0.85;
+    });
+}

--- a/src/scss/_app.scss
+++ b/src/scss/_app.scss
@@ -1,6 +1,25 @@
 .app {
-    background-color: $color-surface;
+    display: block;
+}
+
+.app-frame {
+    background: var(--app-frame-gradient, rgba($color-text, 0.1));
     border-radius: $radius-lg;
+    padding: 4px;
+    transition: background 0.6s ease;
+
+    @media all and (min-width: $breakpoint-desktop) {
+        padding: 6px;
+    }
+}
+
+.app-card {
+    background-color: $color-surface;
+    border-radius: calc(#{$radius-lg} - 4px);
     box-shadow: $shadow-lg;
     overflow: hidden;
+
+    @media all and (min-width: $breakpoint-desktop) {
+        border-radius: calc(#{$radius-lg} - 6px);
+    }
 }

--- a/src/scss/_heading.scss
+++ b/src/scss/_heading.scss
@@ -20,7 +20,7 @@
 
 .heading__icon {
     display: inline-block;
-    font-size: 1.5em;
+    font-size: 1.15em;
     line-height: 1;
 
     @media all and (min-width: $breakpoint-desktop) {
@@ -34,7 +34,7 @@
     background-clip: text;
     color: transparent;
     font-family: 'Baloo 2', 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
-    font-size: 1.6em;
+    font-size: 1.25em;
     font-weight: 700;
     letter-spacing: 0.02em;
 
@@ -45,7 +45,11 @@
 
 .heading__info {
     color: $color-text-muted;
-    font-size: 0.9em;
+    font-size: 0.78em;
     margin: 0.4em 0 0;
     text-align: center;
+
+    @media all and (min-width: $breakpoint-desktop) {
+        font-size: 0.9em;
+    }
 }


### PR DESCRIPTION
Adds Web Audio API tones for car checks/replay and a short victory melody
on win, shrinks heading text sizes for narrow phone screens, and wraps the
app card in a rainbow border that fills in segment by segment, in each
car's color, as that car gets checked off.

https://claude.ai/code/session_01QA3p4DdjsxGsJc1wwS4cua