### PR TITLE
Add a sticky mobile app-header bar for the logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Car Rainbow are documented here. Versions follow [Semantic Versioning](https://semver.org/); dates reflect when each change landed on `main`.
 
+## [1.4.0] - 2026-06-07
+
+### Added
+
+- A small sticky `.app-header` bar (`_app-header.scss`) showing the rainbow logo at the top of the viewport on mobile, giving the page an app-like feel as you scroll
+
+### Changed
+
+- The full `.heading` logo (icon + title) is now hidden on mobile and only shown at the desktop breakpoint, since the compact `.app-header` takes over that role on narrow viewports
+
 ## [1.3.0] - 2026-06-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "car-rainbow",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "",
   "source": "src/index.html",
   "scripts": {

--- a/src/index.html
+++ b/src/index.html
@@ -10,6 +10,12 @@
         <link href="./scss/style.scss" rel="stylesheet" />
     </head>
     <body>
+        <header class="app-header">
+            <h1 class="app-header__logo">
+                <span class="app-header__icon" aria-hidden="true">🌈</span>
+                <span class="app-header__title">Car Rainbow</span>
+            </h1>
+        </header>
         <main class="container">
             <div class="heading">
                 <h1 class="heading__logo">

--- a/src/scss/_app-header.scss
+++ b/src/scss/_app-header.scss
@@ -1,0 +1,40 @@
+.app-header {
+    align-items: center;
+    background-color: rgba($color-surface, 0.92);
+    backdrop-filter: blur(6px);
+    box-shadow: $shadow-sm;
+    display: flex;
+    justify-content: center;
+    padding: 0.6em 0;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+
+    @media all and (min-width: $breakpoint-desktop) {
+        display: none;
+    }
+}
+
+.app-header__logo {
+    align-items: center;
+    display: flex;
+    gap: 0.3em;
+    margin: 0;
+}
+
+.app-header__icon {
+    display: inline-block;
+    font-size: 1.05em;
+    line-height: 1;
+}
+
+.app-header__title {
+    background: linear-gradient(90deg, #ff3b3b, #ff9a3b, #ffd93b, #4ade80, #38bdf8, #a78bfa);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    font-family: 'Baloo 2', 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+    font-size: 1em;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+}

--- a/src/scss/_heading.scss
+++ b/src/scss/_heading.scss
@@ -12,10 +12,14 @@
 
 .heading__logo {
     align-items: center;
-    display: flex;
+    display: none;
     gap: 0.3em;
     justify-content: center;
     margin: 0;
+
+    @media all and (min-width: $breakpoint-desktop) {
+        display: flex;
+    }
 }
 
 .heading__icon {

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -32,6 +32,7 @@ $transition-base: 0.25s ease;
 
 // Components
 @import '_app.scss';
+@import '_app-header.scss';
 @import '_button.scss';
 @import '_car-rainbow.scss';
 @import '_car.scss';


### PR DESCRIPTION
Moves the logo into a small, sticky header bar shown only on narrow
viewports, giving the page more of an installed-app feel as it scrolls.
The larger centered heading remains for desktop.

https://claude.ai/code/session_01Gp1crtphnrCeiT1EyuitFQ