### PR TITLE
Add app link to shared win results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Car Rainbow are documented here. Versions follow [Semantic Versioning](https://semver.org/); dates reflect when each change landed on `main`.
 
+## [1.14.1] - 2026-06-08
+
+### Changed
+
+- Shared win results (`buildShareText` in `src/js/share.js`) now include a link to https://carrainbow.quest/ on a second line, so people receiving a shared result can click straight through to play
+
 ## [1.14.0] - 2026-06-07
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "car-rainbow",
-  "version": "1.10.0",
+  "version": "1.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "car-rainbow",
-      "version": "1.10.0",
+      "version": "1.14.1",
       "license": "ISC",
       "dependencies": {
         "react": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "car-rainbow",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Spot all six rainbow-colored cars and check them off — a small free browser game.",
   "source": "src/index.html",
   "scripts": {

--- a/src/js/CarRainbow.test.jsx
+++ b/src/js/CarRainbow.test.jsx
@@ -89,7 +89,7 @@ describe('CarRainbow', () => {
         await findAllCars(user);
         await user.click(screen.getByRole('button', { name: 'Copy result' }));
 
-        expect(writeText).toHaveBeenLastCalledWith('Car Rainbow — Win #1: 🟥🟧🟨🟩🟦🟪');
+        expect(writeText).toHaveBeenLastCalledWith('Car Rainbow — Win #1: 🟥🟧🟨🟩🟦🟪\nPlay at https://carrainbow.quest/');
         expect(await screen.findByRole('button', { name: 'Copied!' })).toBeInTheDocument();
     });
 
@@ -103,7 +103,7 @@ describe('CarRainbow', () => {
             await findAllCars(user);
             await user.click(screen.getByRole('button', { name: 'Share result' }));
 
-            expect(share).toHaveBeenCalledWith({ text: 'Car Rainbow — Win #1: 🟥🟧🟨🟩🟦🟪' });
+            expect(share).toHaveBeenCalledWith({ text: 'Car Rainbow — Win #1: 🟥🟧🟨🟩🟦🟪\nPlay at https://carrainbow.quest/' });
             expect(screen.queryByRole('button', { name: 'Copied!' })).not.toBeInTheDocument();
         } finally {
             delete navigator.share;

--- a/src/js/share.js
+++ b/src/js/share.js
@@ -1,4 +1,4 @@
 export function buildShareText(winNumber, colors, foundOrder) {
     const grid = foundOrder.map((index) => colors[index].emoji).join('');
-    return `Car Rainbow — Win #${winNumber}: ${grid}`;
+    return `Car Rainbow — Win #${winNumber}: ${grid}\nPlay at https://carrainbow.quest/`;
 }

--- a/src/js/share.test.js
+++ b/src/js/share.test.js
@@ -5,12 +5,12 @@ describe('buildShareText', () => {
     it('encodes the colors in find-order as an emoji grid alongside the win number', () => {
         const text = buildShareText(3, RAINBOW_COLORS, [2, 0, 4]);
 
-        expect(text).toBe('Car Rainbow — Win #3: 🟨🟥🟦');
+        expect(text).toBe('Car Rainbow — Win #3: 🟨🟥🟦\nPlay at https://carrainbow.quest/');
     });
 
     it('produces an empty grid when nothing has been found yet', () => {
         const text = buildShareText(1, RAINBOW_COLORS, []);
 
-        expect(text).toBe('Car Rainbow — Win #1: ');
+        expect(text).toBe('Car Rainbow — Win #1: \nPlay at https://carrainbow.quest/');
     });
 });


### PR DESCRIPTION
Appends a link to https://carrainbow.quest/ on its own line in buildShareText so people receiving a shared result can click straight through to play.

https://claude.ai/code/session_01VLeugvF3PUFGZcB5ZBgf46